### PR TITLE
fix: prevent simulating more than one asm at a time

### DIFF
--- a/src/components/VmSimulator/hooks/useAsmGenerator.js
+++ b/src/components/VmSimulator/hooks/useAsmGenerator.js
@@ -144,6 +144,7 @@ const useAsmGenerator = ({
   useEffect(() => {
     if (!shouldExecAsm) return
     setShouldExecAsm(false)
+    setIsSimulating(true)
     const now = simulateAsmExecution(assembler.parser) || {}
     const shouldSkipNext = isSkipping || now.shouldSkip
     setIsAboutToExecAsm(false)

--- a/src/components/VmSimulator/hooks/useAsmStepwiseSimulator.js
+++ b/src/components/VmSimulator/hooks/useAsmStepwiseSimulator.js
@@ -259,16 +259,21 @@ const useAsmStepwiseSimulator = ({
       const address = parseInt(state.aRegister)
       const jump = parser.jump()
       if (jump) {
-        return setters.asmDescription(ASM_JUMP_DESCRIPTIONS[jump](address))
+        const jumpDescriber = ASM_JUMP_DESCRIPTIONS[jump && jump.trim()]
+        return setters.asmDescription(jumpDescriber && jumpDescriber(address))
       }
       const dest = parser.dest()
       const comp = parser.comp()
+      const compDescriber = ASM_COMP_DESCRIPTIONS[comp && comp.trim()]
+      const compDescription = comp.includes('M') ? (
+        compDescriber ? compDescriber(address) : ''
+      ) : compDescriber
+      const destDescriber = ASM_DEST_DESCRIPTIONS[dest && dest.trim()]
+      const destDescription = dest.trim() === 'M' ? (
+        destDescriber ? destDescriber(address) : ''
+      ) : destDescriber
       setters.asmDescription(
-        `${comp.includes('M') ? ASM_COMP_DESCRIPTIONS[comp](address)
-        : ASM_COMP_DESCRIPTIONS[comp]}${
-          dest === 'M' ? ASM_DEST_DESCRIPTIONS[dest](address)
-          : ASM_DEST_DESCRIPTIONS[dest]
-        }`
+        `${compDescription}${destDescription}`
       )
     }
   }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
This is a minor fix PR, the stepwise asm simulation was crashing the app, because it was allowing more than one asm command to be simulated at a time. This PR makes sure that only one asm command gets simulated at a time.
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Does this PR introduce a breaking change?**
NO
<!-- If this PR introduces a breaking change, please describe the impact. -->
<!-- Breaking change is a change in one part of a software system that potentially causes other
components to fail -->

**What needs to be documented once your changes are merged?**
NOTHING
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
